### PR TITLE
update 6to5 dependency to use babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aurelia-Node
 
-This is a NodeJS Express App bundled with the [Skeleton App](https://github.com/aurelia/skeleton-navigation) of the [Aurelia](http://www.aurelia.io/) platform. It sets up a standard navigation-style app using gulp to build your ES6 code with the 6to5 compiler. Karma/Jasmine testing is also configured.
+This is a NodeJS Express App bundled with the [Skeleton App](https://github.com/aurelia/skeleton-navigation) of the [Aurelia](http://www.aurelia.io/) platform. It sets up a standard navigation-style app using gulp to build your ES6 code with the babel compiler. Karma/Jasmine testing is also configured.
 
 For more info please visit the official site: http://www.aurelia.io/
 

--- a/bin/install
+++ b/bin/install
@@ -1,6 +1,6 @@
 var path = require('path');
 var ghdownload = require('github-download')
-  , exec = require('exec');
+  , execFile = require('child_process').execFile;
 
 ghdownload("https://github.com/aurelia/skeleton-navigation.git#master", 'public/app')
 .on('dir', function(dir) {
@@ -16,7 +16,7 @@ ghdownload("https://github.com/aurelia/skeleton-navigation.git#master", 'public/
   console.error(err)
 })
 .on('end', function() {
-  exec('tree', function(err, stdout, sderr) {
+  execFile('tree', function(err, stdout, sderr) {
     console.log(stdout)
   })
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,12 +2,12 @@ var gulp = require('gulp');
 var runSequence = require('run-sequence');
 var del = require('del');
 var vinylPaths = require('vinyl-paths');
-var to5 = require('gulp-6to5');
+var babel = require('gulp-babel');
 var jshint = require('gulp-jshint');
 var stylish = require('jshint-stylish');
 var yuidoc = require("gulp-yuidoc");
 var changelog = require('conventional-changelog');
-var assign = Object.assign || require('object.assign');
+var assign = Object.assign || require('object-assign');
 var fs = require('fs');
 var bump = require('gulp-bump');
 var browserSync = require('browser-sync');
@@ -36,7 +36,6 @@ var compilerOptions = {
   sourceRoot: '',
   moduleRoot: '',
   moduleIds: false,
-  runtime: false,
   experimental: false,
   format: {
     comments: false,
@@ -61,7 +60,7 @@ gulp.task('build-system', function () {
   return gulp.src(path.source)
     .pipe(plumber())
     .pipe(changed(path.output, {extension: '.js'}))
-    .pipe(to5(assign({}, compilerOptions, {modules:'system'})))
+    .pipe(babel(assign({}, compilerOptions, {modules:'system'})))
     .pipe(gulp.dest(path.output));
 });
 
@@ -133,7 +132,7 @@ function reportChange(event){
 gulp.task('nodemon', function (cb) {
   return nodemon({
     script: 'app.js'
-  }).on('start', function () {
+  }).on('end', function () {
       cb();
   });
 });

--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
   "scripts": {
     "start": "gulp watch"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/zewa666/aurelia-node.git"
+  },
   "dependencies": {
     "body-parser": "~1.8.1",
     "cookie-parser": "~1.3.3",
     "debug": "~2.0.0",
-    "exec": "*",
     "express": "~4.9.0",
     "github-download": "*",
     "swig": "^1.4.2"
@@ -20,7 +23,7 @@
     "conventional-changelog": "0.0.11",
     "del": "^1.1.0",
     "gulp": "^3.8.10",
-    "gulp-6to5": "^2.0.0",
+    "gulp-babel": "^4.0.0",
     "gulp-bump": "^0.1.11",
     "gulp-changed": "^1.1.0",
     "gulp-jshint": "^1.9.0",
@@ -29,11 +32,11 @@
     "jasmine-core": "^2.1.3",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.28",
-    "karma-6to5-preprocessor": "^1.0.0",
+    "karma-babel-preprocessor": "^4.0.1",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.2",
     "karma-jspm": "^1.0.1",
-    "object.assign": "^1.0.3",
+    "object-assign": "^2.0.0",
     "run-sequence": "^1.0.2",
     "vinyl-paths": "^1.0.0",
     "gulp-nodemon": "^1.0.4"


### PR DESCRIPTION
Hi, Thanks for writing this repo. I modified it a bit to remove deprecation warnings and make it work using the documentation you wrote.
- update package.json
- remove deprecated dependencies
- create .gitignore in public to keep directory structure for (prevent error)
- fix "Called callback too many times" gulp error
