### PR TITLE
Remove duplicate file sync step

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,7 +105,6 @@ gulp.task('update-own-deps', function(){
 
 gulp.task('browser-sync', ['build', 'nodemon'], function() {
   browserSync.init({
-    files: ['public/**/*.*'],
     proxy: 'http://localhost:9000',
     port: 7000,
     browser: ['google chrome']


### PR DESCRIPTION
On my Windows PC, "gulp watch" for this project takes a minute to fully start and 40 seconds on each refresh. I narrowed down the problem to a duplication in file watch processes. This PR fixes the issue. 

This is discussed in the following up-stream repo:
https://github.com/aurelia/skeleton-navigation/issues/165

Let me know if this makes sense.
